### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/portaPrince/experiments/matplotlibHelpers/cursors.py
+++ b/portaPrince/experiments/matplotlibHelpers/cursors.py
@@ -37,8 +37,8 @@ class SnaptoCursor(object):
         self.lx.set_ydata(y)
         self.ly.set_xdata(x)
 
-        self.txt.set_text('x=%1.2f, y=%1.2f' % (x, y))
-        print('x=%1.2f, y=%1.2f' % (x, y))
+        self.txt.set_text('x={0:1.2f}, y={1:1.2f}'.format(x, y))
+        print('x={0:1.2f}, y={1:1.2f}'.format(x, y))
         plt.draw()
         
 class Cursor(object):
@@ -59,5 +59,5 @@ class Cursor(object):
         self.lx.set_ydata(y)
         self.ly.set_xdata(x)
 
-        self.txt.set_text('x=%1.2f, y=%1.2f' % (x, y))
+        self.txt.set_text('x={0:1.2f}, y={1:1.2f}'.format(x, y))
         plt.draw()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:flindt:portaPrince?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:flindt:portaPrince?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
